### PR TITLE
Change Golang -> Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repo builds `appthreat/sast-scan` (and `quay.io/appthreat/sast-scan`), a co
 | bom                  | cdxgen                             |
 | credscan             | gitleaks                           |
 | depscan              | dep-scan                           |
-| golang               | gosec, staticcheck                 |
+| go                   | gosec, staticcheck                 |
 | java                 | cdxgen, gradle, find-sec-bugs, pmd |
 | json                 | jq, jsondiff, jsonschema           |
 | kotlin               | detekt                             |
@@ -49,7 +49,7 @@ This repo builds `appthreat/sast-scan` (and `quay.io/appthreat/sast-scan`), a co
 ## Bundled languages/runtime
 
 - jq
-- Golang 1.12
+- Go 1.12
 - Python 3.6
 - OpenJDK 11 (jre)
 - Ruby 2.5.5
@@ -66,7 +66,7 @@ Some reports get converted into an open-standard called [SARIF](https://sarifweb
 - Python - bandit
 - Node.js - NodeJsScan
 - Java - pmd, find-sec-bugs
-- Golang - gosec, staticcheck
+- Go - gosec, staticcheck
 - Terraform - tfsec
 
 ## Usage

--- a/lib/config.py
+++ b/lib/config.py
@@ -29,7 +29,7 @@ scan_types = [
     "bom",
     "credscan",
     "depscan",
-    "golang",
+    "go",
     "java",
     "kotlin",
     "kubernetes",
@@ -128,7 +128,7 @@ scan_tools_args_map = {
         "--report_file",
         "%(report_fname_prefix)s.json",
     ],
-    "golang": {
+    "go": {
         "gosec": [
             "gosec",
             "-fmt=json",
@@ -165,7 +165,7 @@ tool_purpose_message = {
     "findsecbugs": "Security audit by Find Security Bugs",
     "pmd": "Static code analysis by PMD",
     "gitleaks": "Secrets audit by gitleaks",
-    "gosec": "Golang security checks by gosec",
+    "gosec": "Go security checks by gosec",
     "tfsec": "Terraform static analysis by tfsec",
     "shellcheck": "Shell script analysis by shellcheck",
     "bandit": "Security audit for python by bandit",

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -68,7 +68,7 @@ def detect_project_type(src_dir):
         project_types.append("nodejs")
         depscan_supported = True
     if find_files(src_dir, "go.sum") or find_files(src_dir, "Gopkg.lock"):
-        project_types.append("golang")
+        project_types.append("go")
         depscan_supported = True
     if find_files(src_dir, "Cargo.lock"):
         project_types.append("rust")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -32,8 +32,8 @@ def test_scan_tools_map():
 
 def test_override():
     build_break_rules = config.get("build_break_rules").copy()
-    golang_cmd = config.get("scan_tools_args_map").get("golang")
-    assert list(golang_cmd.keys()) == ["gosec", "staticcheck"]
+    go_cmd = config.get("scan_tools_args_map").get("go")
+    assert list(go_cmd.keys()) == ["gosec", "staticcheck"]
     test_data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
     config.set("SAST_SCAN_SRC_DIR", test_data_dir)
     config.reload()
@@ -41,6 +41,6 @@ def test_override():
     new_rules = config.get("build_break_rules")
     assert build_break_rules != new_rules
     # Test if we are able to override a command
-    golang_cmd = config.get("scan_tools_args_map").get("golang")
-    assert golang_cmd[0] == "echo"
+    go_cmd = config.get("scan_tools_args_map").get("go")
+    assert go_cmd[0] == "echo"
     assert config.get("scan_type") == "credscan,java"

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -212,7 +212,7 @@ def test_gosec_convert_issue():
         jsondata = json.loads(data)
         assert (
             jsondata["runs"][0]["tool"]["driver"]["name"]
-            == "Golang security checks by gosec"
+            == "Go security checks by gosec"
         )
         assert jsondata["runs"][0]["results"][0]["message"]["text"]
         assert jsondata["runs"][0]["properties"]["metrics"] == {


### PR DESCRIPTION
The official name of the language is `Go` and not `Golang`. I've changed
all the places we were using the wrong name.

https://en.wikipedia.org/wiki/Go_(programming_language)